### PR TITLE
generator: properly map uint types to respective Rust types

### DIFF
--- a/generator/workdir/openapi-generator.yaml
+++ b/generator/workdir/openapi-generator.yaml
@@ -3,6 +3,11 @@ library: hyper
 avoidBoxedModels: true
 bestFitInt: true
 supportAsync: true
+typeMappings:
+  uint16: u16
+  uint32: u32
+  uint64: u64
+  uint8: u8
 useSingleRequestParameter: true
 packageName: cloud-hypervisor-client
 packageVersion: 0.3.0


### PR DESCRIPTION
This fixes weird type mappings where types that have `uint*` get converted literally, while there is no said type in the schema because they are simply just `u*` number types in Rust